### PR TITLE
Results missing links

### DIFF
--- a/content/04.results.md
+++ b/content/04.results.md
@@ -151,8 +151,8 @@ Each bin contains a total of 200 annotated pairs and is based on the percentiles
 
 Many journals require that authors update preprints with links to the published version of their article.
 This is accomplished in two ways: _bioRxiv_ may detect the link and automatically add it or authors may notify _bioRxiv_ that their preprint was published.
-Missing preprint-publication links can make it more difficult to identify the version of record of scientific manuscripts, and has been used to estimate the fraction of articles that are eventually published [@doi:10.7554/eLife.45133].
-We used distance in the document space to identify preprints without an annotated publication but that contained very similar content to published articles.
+Missing preprint-publication links can make it more difficult to identify the latest version of scientific manuscripts and estimate the fraction of articles that are eventually published [@doi:10.7554/eLife.45133].
+We used distance in the document space to identify preprints without an annotated publication but contained very similar content to published articles.
 We found that distances between preprints and their corresponding published versions were lower than preprints paired with a random article published in the same journal (Figure {@fig:article_distance_distributions}).
 This observation suggests that pairs with low embedding distances could be considered a true match, so we separated articles into quantiles based on the distribution of distances between true preprint-publication pairs.
 We curated 50 potential preprint-publication pairs from each of four quantiles in duplicate, and found a high inter-rater reliability for this task achieving a Cohen's Kappa [@doi:10.1177/001316446002000104] of 91.7%.

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -64,6 +64,19 @@ Tokens with an odds ratio of less than one are focused on data availability, and
 2. Show plot of the principal components and the scatterplot
 3. Mention that the word clouds can be found at xyz
 
+### Filling In Missing Preprint - Published Links
+
+![
+](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/biorxiv_article_distance.svg){#fig:article_distance_distributions}
+
+![
+Accuracy decreases as the article distances become larger and larger. 
+](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/distance_bin_accuracy.svg){#fig:article_bin_accuracy}
+
+The difference of distrbutions indicates that true matches have lower distances than off target matches.
+The interrator reliability score is 91.7%.
+We identified about 10% missing links that can be added towards the biorxiv repository.
+
 ### Journal Recommendations/Audience Associations
 1. Title will change once analysis is finished 
 2. Provide key figure for this section and take-home message

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -77,11 +77,28 @@ This bar chart depicts the fraction of true positives over the total number of p
 Each bin contains a total of 200 annotated pairs and is based on the percentiles of the preprint-published distribution.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/distance_bin_accuracy.svg){#fig:article_bin_accuracy}
 
-Using Euclidean distance between article embeddings is a promising approach to finding missing links between preprints and published versions.
-There is a notable distance between the true distribution (preprint vs published) and the null distribution (preprint vs random) (Figure {@fig:article_distance_distributions}), which suggests that article pairs with low enough distances may indicate a potential link.
-We annotated 200 potential links with a high inter-rater reliability score (Cohen's Kappa [@doi:10.1177/001316446002000104]) of 91.7%, which suggests high agreement between annotators.
-Furthermore, article pairs whose distance falls below the 50th percentile have a high chance of being a true positive (Figure {@fig:article_bin_accuracy}).
+As preprints transition to being published typically authors report back to bioRxiv that their preprint has been published; however, authors may fail to report to bioRxiv about their publication.
+These events generate gaps within bioRxiv where preprints are not linked to their respective published versions. 
+We sought to use document embedding distance as a way to fill in these missing links within bioRxiv.
+We noticed that preprints and thier published counterparts have lower distances than preprints paired with a random article (Figure {@fig:article_distance_distributions}).
+This observation suggests that preprint-published pairs with low enough distances may indicate a potential link.
+We successfully annotated 200 potential links with a high inter-rater reliability score of 91.7% (Cohen's Kappa [@doi:10.1177/001316446002000104]).
+Out of these two hundred article pairs we found that pairs within both the 25th-50th and the 0-25th percentile bins have almost 100% chance of being a true positive (Figure {@fig:article_bin_accuracy}).
+Upon combining these two bins we were able to fill in 1,720 missing links from bioRxiv.
 
+![
+The overall fraction of published preprints is higher than originally estimated in [@doi:10.7554/eLife.45133].
+This line plot shows the publication rate of preprints since bioRxiv first started.
+The x-axis represents months since bioRxiv started and the y-axis represents the proportion of preprints published.
+The light blue line represents the publication rate estimated by Abdill et al. [@doi:10.7554/eLife.45133]. 
+The dark blue line represents the updated publication rate without missing links added while the dark green line is the updated publication rate with missing links added.
+The horizontal lines represents the overall proportion of preprints  that are published.
+](https://raw.githubusercontent.com/greenelab/annorxiver/8dbc3f8e248ff3e7958c3420363443f0c61b2cc1/biorxiv/article_distances/output/figures/publication_rate.png){#fig:updated_pub_rate}
+
+We aimed to reassess the true number of preprints that were published after correcting for our found missing links.
+We observed that majority of missing links were for preprints posted within 2017-2018 (Figure {@fig: updated_pub_rate}).
+Furthermore, we observed an increase on the overall proportion of preprints published (Figure {@fig: updated_pub_rate})
+This confirms that preprints are being published with great success; however, our estimated rate is an underestimate on the true proportion of published preprints as majority of articles are published closed access.
 
 ### Journal Recommendations/Audience Associations
 1. Title will change once analysis is finished 

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -136,27 +136,27 @@ This split is evident in Figure {@fig:pca2_pointplot} as enriched categories alo
 As with the first principal component we provide example preprints from the systems biology category to reinforce this concept (Supplemental Table {@tbl:five_pc2_table}). 
 More principal component word clouds can be found on our journal recommender website ([greenelab.github.io/annorxiver-journal-recommender](https://greenelab.github.io/annorxiver-journal-recommender/)) and within our online repository (see Data Availability).
 
-### Mending Missing Preprints to Published Versions Linkss
+### Mending Missing Preprints to Published Versions Links
 
 ![
-The distances between preprints and their published version is on average lower than the distance between preprints and a randomly selected article.
+The distances between preprints and their published version is on average lower than the distance between preprints and a randomly selected published article.
 This violin plot shows the distribution of distances between both categories.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/biorxiv_article_distance.svg){#fig:article_distance_distributions}
 
 ![
-Accuracy decreases as preprint distances become larger and larger. 
+Accuracy decreases as preprint-published article distances become larger and larger. 
 This bar chart depicts the fraction of true positives over the total number of pairs in each bin.
 Each bin contains a total of 200 annotated pairs and is based on the percentiles of the preprint-published distribution.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/distance_bin_accuracy.svg){#fig:article_bin_accuracy}
 
-As preprints transition to being published typically authors report back to bioRxiv that their preprint has been published; however, authors may fail to report to bioRxiv about their publication.
-These events generate gaps within bioRxiv where preprints are not linked to their respective published versions. 
-We sought to use document embedding distance as a way to fill in these missing links within bioRxiv.
-We noticed that preprints and thier published counterparts have lower distances than preprints paired with a random article (Figure {@fig:article_distance_distributions}).
-This observation suggests that preprint-published pairs with low enough distances may indicate a potential link.
-We successfully annotated 200 potential links with a high inter-rater reliability score of 91.7% (Cohen's Kappa [@doi:10.1177/001316446002000104]).
-Out of these two hundred article pairs we found that pairs within both the 25th-50th and the 0-25th percentile bins have almost 100% chance of being a true positive (Figure {@fig:article_bin_accuracy}).
-Upon combining these two bins we were able to fill in 1,720 missing links from bioRxiv.
+When a preprint gets published typically authors notify bioRxiv on the publication event; however, there are instances where authors may fail to notify bioRxiv.
+These events generate gaps where preprints end up unlinked to their respective published versions. 
+We sought to use document embedding distance as a way to fill in these missing link gaps.
+We noticed distances between preprints and their published counterparts are lower than preprints paired with a random published article (Figure {@fig:article_distance_distributions}).
+This observation suggests that pairs with low embedding distances could be considered a true match.
+We annotated a sample of 200 pairs with a high inter-rater reliability score of 91.7% (Cohen's Kappa [@doi:10.1177/001316446002000104]).
+Out of these two hundred pairs we found that pairs with an embedding distance in the 0-25th and 25th-50th percentile bins have almost 98% chance of being a true match (Figure {@fig:article_bin_accuracy}).
+Using these two bins, we were able to fill in 1,720 missing links within bioRxiv.
 
 ![
 The overall fraction of published preprints is higher than originally estimated in [@doi:10.7554/eLife.45133].
@@ -164,13 +164,13 @@ This line plot shows the publication rate of preprints since bioRxiv first start
 The x-axis represents months since bioRxiv started and the y-axis represents the proportion of preprints published.
 The light blue line represents the publication rate estimated by Abdill et al. [@doi:10.7554/eLife.45133]. 
 The dark blue line represents the updated publication rate without missing links added while the dark green line is the updated publication rate with missing links added.
-The horizontal lines represents the overall proportion of preprints  that are published.
+The horizontal lines represent the overall proportion of preprints  that are published.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/8dbc3f8e248ff3e7958c3420363443f0c61b2cc1/biorxiv/article_distances/output/figures/publication_rate.png){#fig:updated_pub_rate}
 
-We aimed to reassess the true number of preprints that were published after correcting for our found missing links.
-We observed that majority of missing links were for preprints posted within 2017-2018 (Figure {@fig: updated_pub_rate}).
-Furthermore, we observed an increase on the overall proportion of preprints published (Figure {@fig: updated_pub_rate})
-This confirms that preprints are being published with great success; however, our estimated rate is an underestimate on the true proportion of published preprints as majority of articles are published closed access.
+We utilized our newly found links to reassess the overall preprint publication rate.
+We observed that majority of missing links were for preprints posted around 2017-2018 (Figure {@fig:updated_pub_rate}).
+Furthermore, we observed that the overall proportion of preprints published increased to 46% (Figure {@fig:updated_pub_rate}); however, this is an underestimate on the true proportion of preprints published.
+Lastly, the increase in overall preprints published suggests that overtime more and more preprints are getting published with moderate success.
 
 ### Journal Recommendations/Audience Associations
 1. Title will change once analysis is finished 

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -136,27 +136,28 @@ This split is evident in Figure {@fig:pca2_pointplot} as enriched categories alo
 As with the first principal component we provide example preprints from the systems biology category to reinforce this concept (Supplemental Table {@tbl:five_pc2_table}). 
 More principal component word clouds can be found on our journal recommender website ([greenelab.github.io/annorxiver-journal-recommender](https://greenelab.github.io/annorxiver-journal-recommender/)) and within our online repository (see Data Availability).
 
-### Mending Missing Preprints to Published Versions Links
+### Identifying preprints that were not linked with their corresponding publications
 
 ![
-The distances between preprints and their published version is on average lower than the distance between preprints and a randomly selected published article.
+The distances between preprints and their published version was on average lower than the distance between preprints and a randomly selected published article in the same journal.
 This violin plot shows the distribution of distances between both categories.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/biorxiv_article_distance.svg){#fig:article_distance_distributions}
 
 ![
-Accuracy decreases as preprint-published article distances become larger and larger. 
+The proportion of publication-preprint pairs decreased as the distance for publication-preprint pairs increased.
 This bar chart depicts the fraction of true positives over the total number of pairs in each bin.
 Each bin contains a total of 200 annotated pairs and is based on the percentiles of the preprint-published distribution.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/distance_bin_accuracy.svg){#fig:article_bin_accuracy}
 
-When a preprint gets published typically authors notify bioRxiv on the publication event; however, there are instances where authors may fail to notify bioRxiv.
-These events generate gaps where preprints end up unlinked to their respective published versions. 
-We sought to use document embedding distance as a way to fill in these missing link gaps.
-We noticed distances between preprints and their published counterparts are lower than preprints paired with a random published article (Figure {@fig:article_distance_distributions}).
-This observation suggests that pairs with low embedding distances could be considered a true match.
-We annotated a sample of 200 pairs with a high inter-rater reliability score of 91.7% (Cohen's Kappa [@doi:10.1177/001316446002000104]).
-Out of these two hundred pairs we found that pairs with an embedding distance in the 0-25th and 25th-50th percentile bins have almost 98% chance of being a true match (Figure {@fig:article_bin_accuracy}).
-Using these two bins, we were able to fill in 1,720 missing links within bioRxiv.
+Many journals require that authors update preprints with links to the published version of their article.
+This is accomplished in two ways: _bioRxiv_ may detect the link and automatically add it or authors may notify _bioRxiv_ that their preprint was published.
+Missing preprint-publication links can make it more difficult to identify the version of record of scientific manuscripts, and has been used to estimate the fraction of articles that are eventually published [@doi:10.7554/eLife.45133].
+We used distance in the document space to identify preprints without an annotated publication but that contained very similar content to published articles.
+We found that distances between preprints and their corresponding published versions were lower than preprints paired with a random article published in the same journal (Figure {@fig:article_distance_distributions}).
+This observation suggests that pairs with low embedding distances could be considered a true match, so we separated articles into quantiles based on the distribution of distances between true preprint-publication pairs.
+We curated 50 potential preprint-publication pairs from each of four quantiles in duplicate, and found a high inter-rater reliability for this task achieving a Cohen's Kappa [@doi:10.1177/001316446002000104] of 91.7%.
+Out of these two hundred pairs we found that approximately 98% of pairs with an embedding distance in the 0-25th and 25th-50th percentile bins were true matches (Figure {@fig:article_bin_accuracy}).
+These two bins contained 1,720 preprint-article pairs, suggesting that many preprints have been published but not previously connected with their published versions.
 
 ![
 The overall fraction of published preprints is higher than originally estimated in [@doi:10.7554/eLife.45133].
@@ -167,10 +168,10 @@ The dark blue line represents the updated publication rate without missing links
 The horizontal lines represent the overall proportion of preprints  that are published.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/8dbc3f8e248ff3e7958c3420363443f0c61b2cc1/biorxiv/article_distances/output/figures/publication_rate.png){#fig:updated_pub_rate}
 
-We utilized our newly found links to reassess the overall preprint publication rate.
-We observed that majority of missing links were for preprints posted around 2017-2018 (Figure {@fig:updated_pub_rate}).
-Furthermore, we observed that the overall proportion of preprints published increased to 46% (Figure {@fig:updated_pub_rate}); however, this is an underestimate on the true proportion of preprints published.
-Lastly, the increase in overall preprints published suggests that overtime more and more preprints are getting published with moderate success.
+We overlaid these new annotations onto existing annotations to reassess the overall preprint publication rate reported by Abdill et al. [@doi:10.7554/eLife.45133].
+Our filtering criteria were intentionally stringent, so the increased estimate of publication rate amounts to a few percent (Figure {@fig:updated_pub_rate}).
+Many of these missed annotations were for preprints posted in the 2017-2018 interval.
+As opposed to those published in 2019 and later, these preprints are old enough that they are likely to have been published but it was interesting that the rate was not observed to be higher for older preprints.
 
 ### Journal Recommendations/Audience Associations
 1. Title will change once analysis is finished 

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -64,18 +64,24 @@ Tokens with an odds ratio of less than one are focused on data availability, and
 2. Show plot of the principal components and the scatterplot
 3. Mention that the word clouds can be found at xyz
 
-### Filling In Missing Preprint - Published Links
+### Mending Missing Preprints to Published Versions Linkss
 
 ![
+The distances between preprints and their published version is on average lower than the distance between preprints and a randomly selected article.
+This violin plot shows the distribution of distances between both categories.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/biorxiv_article_distance.svg){#fig:article_distance_distributions}
 
 ![
-Accuracy decreases as the article distances become larger and larger. 
+Accuracy decreases as preprint distances become larger and larger. 
+This bar chart depicts the fraction of true positives over the total number of pairs in each bin.
+Each bin contains a total of 200 annotated pairs and is based on the percentiles of the preprint-published distribution.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/131dcac75d179cb36992af4a31188031800c0958/biorxiv/article_distances/output/figures/distance_bin_accuracy.svg){#fig:article_bin_accuracy}
 
-The difference of distrbutions indicates that true matches have lower distances than off target matches.
-The interrator reliability score is 91.7%.
-We identified about 10% missing links that can be added towards the biorxiv repository.
+Using Euclidean distance between article embeddings is a promising approach to finding missing links between preprints and published versions.
+There is a notable distance between the true distribution (preprint vs published) and the null distribution (preprint vs random) (Figure {@fig:article_distance_distributions}), which suggests that article pairs with low enough distances may indicate a potential link.
+We annotated 200 potential links with a high inter-rater reliability score (Cohen's Kappa [@doi:10.1177/001316446002000104]) of 91.7%, which suggests high agreement between annotators.
+Furthermore, article pairs whose distance falls below the 50th percentile have a high chance of being a true positive (Figure {@fig:article_bin_accuracy}).
+
 
 ### Journal Recommendations/Audience Associations
 1. Title will change once analysis is finished 


### PR DESCRIPTION
This PR discusses the experiment on filling in missing published links within bioRxiv and re-estimating the overall amount of preprints published.