### PR TITLE
Made Larry's suggested changes

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -65,8 +65,8 @@ Lastly, we binned the remaining pairs based on percentiles from the annotated pa
 We randomly sampled 50 articles from each bin for manual annotation.
 We shuffled these four sets to produce a list of 200 potential preprint-published pairs with a randomized order.
 We supplied these candidates to two scientists to manually determine if each link between a preprint and a putative matched version was correct or incorrect.
-After the curation process we encountered eight mismatches.
-These mismatches were supplied to a third scientist, who carefully reviewed each case and made a final determination.
+After the curation process, we encountered eight disagreements between reviewers.
+These disagreements were supplied to a third scientist, who carefully reviewed each case and made a final determination.
 Lastly, we used this curated set to evaluate the extent to which distance in the embedding space revealed true but unannotated links between preprints and their published verisons.
 
 ### Journal Recommendation

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -7,7 +7,7 @@ BioRxiv [@doi:10.1101/833400] is a repository of biological and biomedical resea
 We downloaded an xml snapshot of this repository on February 3, 2020 from   bioRxiv's Amazon S3 resource [@url:https://www.biorxiv.org/tdm] that contained the full text and image content of 98,023 preprints.
 Preprints on bioRxiv are versioned, and in our snapshot 26,905 of 98,023 contained more than one version.
 When preprints had multiple versions, we used only the latest one. 
-Preprints in this snapshot were grouped into one of twenty-nine different categories.
+Preprints in this snapshot were grouped by researchers at bioRxiv into one of twenty-nine different categories.
 Each preprint was also classified as a new result, confirmatory finding, or contradictory finding.
 Some preprints in this snapshot have been withdrawn from bioRxiv.
 When a preprint is withdrawn, its content is replaced with the reason for withdrawal.
@@ -72,7 +72,8 @@ Lastly, we used this curated set to evaluate the extent to which distance in the
 
 ### Journal Recommendation
 
-We aimed to predict the journal a paper would eventually be published in based on its embedding representation.
+Determining the best journal venue for a preprint is a non-trivial task as there are too many options for authors to decide.
+We sought to provide a resource that recommends journals based on a preprint's embedding representation.
 We illustrate our recommendations as a short list along with a network visualization available at [https://greenelab.github.io/annorxiver-journal-recommender/](https://greenelab.github.io/annorxiver-journal-recommender/).
 Since we sought to examine if embeddings were related to publication venue, we used a simple k-nearest neighbors approach with Euclidean distance to recommend journals.
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -7,7 +7,7 @@ BioRxiv [@doi:10.1101/833400] is a repository of biological and biomedical resea
 We downloaded an xml snapshot of this repository on February 3, 2020 from   bioRxiv's Amazon S3 resource [@url:https://www.biorxiv.org/tdm] that contained the full text and image content of 98,023 preprints.
 Preprints on bioRxiv are versioned, and in our snapshot 26,905 of 98,023 contained more than one version.
 When preprints had multiple versions, we used only the latest one. 
-Preprints in this snapshot were grouped by researchers at bioRxiv into one of twenty-nine different categories.
+Preprints in this snapshot were grouped by researchers submitting to _bioRxiv_ into one of twenty-nine different categories.
 Each preprint was also classified as a new result, confirmatory finding, or contradictory finding.
 Some preprints in this snapshot have been withdrawn from bioRxiv.
 When a preprint is withdrawn, its content is replaced with the reason for withdrawal.
@@ -67,7 +67,7 @@ We randomly sampled 50 articles from each bin for manual annotation.
 We shuffled these four sets to produce a list of 200 potential preprint-published pairs with a randomized order.
 We supplied these candidates to two scientists to manually determine if each link between a preprint and a putative matched version was correct or incorrect.
 After the curation process, we encountered eight disagreements between reviewers.
-These disagreements were supplied to a third scientist, who carefully reviewed each case and made a final determination.
+The preprint-publication pairs on which reviewers disagreed were supplied to a third scientist, who carefully reviewed each case and made a final determination.
 Lastly, we used this curated set to evaluate the extent to which distance in the embedding space revealed true but unannotated links between preprints and their published verisons.
 
 ### Journal Recommendation

--- a/content/04.results.md
+++ b/content/04.results.md
@@ -9,17 +9,13 @@ Neuroscience and bioinformatics are the two most common topics for preprints on 
 This bar chart depicts the number of preprints that fall into each author-selected topic area.
 ](https://raw.githubusercontent.com/greenelab/annorxiver/35d3ea0de3c9c78e3c524736bbaada00928c88fb/biorxiv/exploratory_data_analysis/output/figures/preprint_category.png){#fig:biorxiv_categories}
 
-![
-Most of bioRxiv's preprints report new research findings.
-This bar chart depicts the number of articles categorized based on author-selected article types.
-](https://raw.githubusercontent.com/greenelab/annorxiver/94874e0f1e35bd667bf3b7c3dc6416068779444f/biorxiv/exploratory_data_analysis/output/figures/preprint_headings.png){#fig:biorxiv_headings}
 
 Each preprint on bioRxiv has an author-selected topic area, and the predominant area in past reports has been neuroscience [@doi:10.7554/eLife.45133].
 Our analysis of the full text release of bioRxiv confirms this previous finding (Figure {@fig:biorxiv_categories}).
 The author-selected topic area abundances that we found in the full text largely matched previous studies [@doi:10.7554/eLife.45133; @doi:10.1001/jama.2017.21168].
 One exception was microbiology, which has a larger share of preprints than in a previous report from 2018 [@doi:10.7554/eLife.45133] (Figure {@fig:biorxiv_categories}).
 Authors also select from three article types when they upload their preprints.
-We found that most preprints are categorized as new results (Figure {@fig:biorxiv_headings}), which is consistent with previous findings [@doi:10.1001/jama.2017.21168].
+We found that nearly all preprints were categorized as new results, which is consistent with previous findings [@doi:10.1001/jama.2017.21168].
 
 #### Global Comparison of bioRxiv and PubMed Central 
 


### PR DESCRIPTION
This PR implements Larry's suggested changes:
- [x] Added a sources that is tangential PMC and BioRxiv corpus for corpora analysis (in a different PR)
- [x] "Preprints in this snapshot were grouped into…” Grouped by whom? -> Added in this PR 
- [x] Update "curation mismatches" to say "disagreements between curators".
- [x] Add rationale for journal recommender system
- [x] Remove bioRxiv_headings figure and just let the sentence communicate the finding itself