### PR TITLE
Corpora Methods Rewrite

### DIFF
--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -16,28 +16,30 @@ As there were very few withdrawn preprints, we did not treat these as a special 
 
 #### PubMed Central Open Access Corpus
 
-PubMed Central (PMC) [@doi:10.1073/pnas.98.2.381] is a repository that contains free-to-read articles.
-PMC articles can be closed access ones from research funded by the United States National Institutes of Health (NIH) appearing after an embargo period or those published under Gold Open Access [@doi:10.1007/s12471-017-1064-2] publishing schemes.
+PubMed Central (PMC) is a digital archive for the United States National Institute of Health's Library of Medicine (NIH/NLM) that contains full text biomedical and life science articles [@doi:10.1073/pnas.98.2.381].
+PMC articles can be closed access ones from research funded by the NIH appearing after an embargo period or those published under Gold Open Access [@doi:10.1007/s12471-017-1064-2] publishing schemes.
 Paper availability within PMC is largely dependent on the journal's participation level [@url:https://www.ncbi.nlm.nih.gov/pmc/about/submission-methods/].
 Individual journals can fully participate in submitting articles to PMC, selectively participate sending only a few papers to PMC, only submit papers according to NIH's public access policy [@url:https://grants.nih.gov/grants/policy/nihgps/html5/section_8/8.2.2_nih_public_access_policy.htm], or not participate at all.
 As of September 2019, PMC had 5,725,819 articles available [@url:https://www.ncbi.nlm.nih.gov/pmc/about/intro/].
-Out of these 5 million articles, about 3 million were open access and available for text processing systems [@doi:10.1093/bioinformatics/btz070; @doi:10.1093/nar/gkz389].
-We downloaded a snapshot of this open access subset on January 31, 2020.
+Out of these 5 million articles, about 3 million were open access (PMCOA) and available for text processing systems [@doi:10.1093/bioinformatics/btz070; @doi:10.1093/nar/gkz389].
+PMC also contains a resource that holds author manuscripts that have already passed the peer review process [@url:https://www.ncbi.nlm.nih.gov/pmc/about/authorms/].
+Since these manuscripts have already been peer reviewed, we kept them out of our analysis as the scope of our work is solely focused on examining the beginning and end of a preprint's lifecycle.
+We downloaded a snapshot of the PMCOA corpus on January 31, 2020.
 This snapshot contained many types of papers: literature reviews, book reviews, editorials, case reports, research articles and more.
-We used only research articles, which aligns with the intended role of bioRxiv, and we refer to these articles as the PMC Corpus.
+We used only research articles, which aligns with the intended role of bioRxiv, and we refer to these articles as the PMCOA Corpus.
 
 #### The New York Times Annotated Corpus
 
 The New York Times Annotated Corpus (NYTAC) is [@sandhaus2008new] is collection of newspaper articles from the New York Times dating from January 1, 1987  to June 19, 2007.
 This collection contains over 1.8 million articles where 1.5 million of those articles have undergone manual entity tagged by library scientists [@sandhaus2008new].
-We downloaded this collection on August 3rd, 2020 from the Linguistic Data Consortium (see Software and Data Availability section) and used the entire collection for our corpora comparison analysis.
+We downloaded this collection on August 3rd, 2020 from the Linguistic Data Consortium (see Software and Data Availability section) and used the entire collection as a negative control for our corpora comparison analysis.
 
 ### Mapping bioRxiv preprints to their published counterparts
 
 We used CrossRef [@doi:10.1629/uksg.233] to identify bioRxiv preprints that were linked to a corresponding published article.
 We accessed CrossRef on July 7th, 2020 and were able to successfully link 23,271 preprint to their published counterparts.
-Out of those 23,271 preprint-published pairs only 17,952 pairs had a published version present within the PMC open access corpus. 
-For our analyses that invovled published links we only focused on the subset of preprints-published pairs that contained a published article within PMC. 
+Out of those 23,271 preprint-published pairs only 17,952 pairs had a published version present within the PMCOA corpus. 
+For our analyses that invovled published links we only focused on the subset of preprints-published pairs that contained a published article within PMCOA. 
 
 ### Comparing Corpora
 <!--

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -40,7 +40,9 @@ Out of those 23,271 preprint-published pairs only 17,952 pairs had a published v
 For our analyses that invovled published links we only focused on the subset of preprints-published pairs that contained a published article within PMC. 
 
 ### Comparing Corpora
-
+<!--
+The Kullback–Leibler divergence measures the extent to which two distributions, but not the specific entities that comprise those distributions, differ.
+-->
 We compared the bioRxiv, PMC, and NYTAC corpora to assess the similarities and differences between them.
 We use the NYTAC as an out-group to assess the similarity of two life sciences repositories when compared with non-life sciences text.
 The corpora contain both words and non-word symbols (e.g., $\pm$), which we refer to together as tokens to avoid confusion.

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -42,9 +42,7 @@ Out of those 23,271 preprint-published pairs only 17,952 pairs had a published v
 For our analyses that invovled published links we only focused on the subset of preprints-published pairs that contained a published article within PMCOA. 
 
 ### Comparing Corpora
-<!--
-The Kullback–Leibler divergence measures the extent to which two distributions, but not the specific entities that comprise those distributions, differ.
--->
+
 We compared the bioRxiv, PMC, and NYTAC corpora to assess the similarities and differences between them.
 We use the NYTAC as an out-group to assess the similarity of two life sciences repositories when compared with non-life sciences text.
 The corpora contain both words and non-word symbols (e.g., $\pm$), which we refer to together as tokens to avoid confusion.

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -11,7 +11,7 @@ Preprints on bioRxiv are versioned, and in our snapshot 26,905 out of 98,023 con
 When preprints had multiple versions, we used the latest one unless otherwise noted.
 Authors submitting preprints to bioRxiv select one of twenty-nine different categories.
 Researchers also select an article type, which can be a new result, confirmatory finding, or contradictory finding.
-Some preprints in this snapshot were withdrawn from bioRxiv: when this happens their content is replaced with the reason for withdrawal.
+Some preprints in this snapshot were withdrawn from bioRxiv: when this happens, their content is replaced with the reason for withdrawal.
 As there were very few withdrawn preprints, we did not treat these as a special case.
 
 #### PubMed Central Open Access Corpus
@@ -37,9 +37,9 @@ We downloaded this collection on August 3rd, 2020 from the Linguistic Data Conso
 ### Mapping bioRxiv preprints to their published counterparts
 
 We used CrossRef [@doi:10.1629/uksg.233] to identify bioRxiv preprints that were linked to a corresponding published article.
-We accessed CrossRef on July 7th, 2020 and were able to successfully link 23,271 preprint to their published counterparts.
+We accessed CrossRef on July 7th, 2020 and were able to successfully link 23,271 preprints to their published counterparts.
 Out of those 23,271 preprint-published pairs only 17,952 pairs had a published version present within the PMCOA corpus. 
-For our analyses that invovled published links we only focused on the subset of preprints-published pairs that contained a published article within PMCOA. 
+For our analyses that involved published links we only focused on the subset of preprints-published pairs that contained a published article within PMCOA.
 
 ### Comparing Corpora
 

--- a/content/03.methods.md
+++ b/content/03.methods.md
@@ -23,7 +23,7 @@ Individual journals can fully participate in submitting articles to PMC, selecti
 As of September 2019, PMC had 5,725,819 articles available [@url:https://www.ncbi.nlm.nih.gov/pmc/about/intro/].
 Out of these 5 million articles, about 3 million were open access (PMCOA) and available for text processing systems [@doi:10.1093/bioinformatics/btz070; @doi:10.1093/nar/gkz389].
 PMC also contains a resource that holds author manuscripts that have already passed the peer review process [@url:https://www.ncbi.nlm.nih.gov/pmc/about/authorms/].
-Since these manuscripts have already been peer reviewed, we kept them out of our analysis as the scope of our work is solely focused on examining the beginning and end of a preprint's lifecycle.
+Since these manuscripts have already been peer reviewed, we kept them out of our analysis as the scope of our work is solely focused on examining the beginning and endpoints of a preprint's lifecycle.
 We downloaded a snapshot of the PMCOA corpus on January 31, 2020.
 This snapshot contained many types of papers: literature reviews, book reviews, editorials, case reports, research articles and more.
 We used only research articles, which aligns with the intended role of bioRxiv, and we refer to these articles as the PMCOA Corpus.


### PR DESCRIPTION
This PR contains updated information on the described corpora section. I added more information about the open access part of PMC and then switch to referring PMCOA as PMCOA per Larry's feedback. Will fix merge conflict as soon as this PR is open.