### PR TITLE
Reordered citations list to remove dangling citations

### DIFF
--- a/content/90.back-matter.md
+++ b/content/90.back-matter.md
@@ -40,7 +40,7 @@ This result supports the notion that bioRxiv contains an influx of neuroscience 
 For both of the top two PCs, the submitter-selected category of systems biology preprints was near the middle of the distribution and had a relatively large interquartile range when compared with other categories (Supplementary Figures {@fig:topic_analysis_panels}D and {@fig:topic_analysis_panels}E), suggesting that systems biology is a broader subfield containing both informatics and cellular biology approaches. 
 
 Examining the top five highest-scoring and bottom five lowest-scoring systems biology preprints along PC1 reinforces its dichotomous theme (Supplementary Table {@tbl:five_pc1_table}).
-Preprints with the highest values [@doi:10.1101/197400;@doi:10.1101/825943;@doi:10.1101/044818;@doi:10.1101/769299;@doi:10.1101/107250] included software packages, machine learning analyses, and other computational biology manuscripts, while preprints with the lowest values [@doi:10.1101/455048;@doi:10.1101/371922;@doi:10.1101/733162;@doi:10.1101/745943;@doi:10.1101/754572] were focused on cellular signaling and protein activity.
+Preprints with the highest values [@doi:10.1101/197400;@doi:10.1101/266775;@doi:10.1101/769299;@doi:10.1101/044818;@doi:10.1101/107250] included software packages, machine learning analyses, and other computational biology manuscripts, while preprints with the lowest values [@doi:10.1101/2019.12.11.872887;@doi:10.1101/745943;@doi:10.1101/455048;@doi:10.1101/733162;@doi:10.1101/754572] were focused on cellular signaling and protein activity.
 We provide the rest of our 50 generated PCs in our online repository (see Software and Data Availability).
 
 | Title [citation]     | PC1  | License | Figure Thumbnail |


### PR DESCRIPTION
There were dangling citations within the supplement which caused a reference issue. Will merge once compilation is complete. No review necessary.